### PR TITLE
Implement initial interface

### DIFF
--- a/quicktree/core.py
+++ b/quicktree/core.py
@@ -8,6 +8,10 @@ from quicktree import helpers
 def main():
     quicktree_struct = helpers.get_quicktree_struct(os.getcwd())
     quicktree_dirs_map = helpers.map_quicktree_dirs(quicktree_struct)
+    terminal_output = \
+        helpers.get_output_str(quicktree_struct, quicktree_dirs_map)
+    print(terminal_output)
+
 
 
 if __name__ == "__main__":

--- a/quicktree/helpers.py
+++ b/quicktree/helpers.py
@@ -61,3 +61,8 @@ def map_quicktree_dirs(struct):
         ret[ret_key] += [sorted_dirs_list[i]]
 
     return ret
+
+
+def get_output_str(struct, map):
+    """TODO: stub"""
+    return ""

--- a/tests/test.py
+++ b/tests/test.py
@@ -276,5 +276,10 @@ class TestMapQuickTreeDirs(unittest.TestCase):
         self.assertDictEqual(expected_map, actual_map)
 
 
+class TestGetOutputStr(unittest.TestCase):
+    def test_stub(self):
+        self.assertTrue(False)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Print the appropriate output when program is first initiated. Show the directories of the cwd in the terminal, and their mapped keys. Show files of cwd too.